### PR TITLE
Fix build scripts Environment variables use on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
     "yaml": "^1.10.2"
   },
   "scripts": {
-    "dev": "PACKAGE_INDEX_CACHE_DIR=.cache next dev",
-    "build": "PACKAGE_INDEX_CACHE_DIR=.cache next build",
-    "start": "PACKAGE_INDEX_CACHE_DIR=.cache next start",
+    "dev": "cross-env PACKAGE_INDEX_CACHE_DIR=.cache next dev",
+    "build": "cross-env PACKAGE_INDEX_CACHE_DIR=.cache next build",
+    "start": "cross-env PACKAGE_INDEX_CACHE_DIR=.cache next start",
     "lint": "next lint"
   },
   "eslintConfig": {
@@ -59,6 +59,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "babel-plugin-styled-components": "^2.0.2",
+    "cross-env": "^7.0.3",
     "typescript": "^4.1.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,7 +3910,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@7.0.3, cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
This PR introduces the cross-env [1] package as a way to run the scripts
on Windows. Otherwise the Env variables won't be recognized correctly

https://c.tenor.com/yQpWaFq57ZEAAAAS/hasbulla.gif

[1]: https://www.npmjs.com/package/cross-env