### PR TITLE
fix: fix flash of unstyled content in SSG build

### DIFF
--- a/components/BetaBanner.tsx
+++ b/components/BetaBanner.tsx
@@ -6,7 +6,7 @@ export const BetaBanner = () => {
   const [isShowing, setIsShowing] = useLocalStorage("showBetaBanner", true);
 
   // Don't render the Beta banner when SSR
-  if (typeof window === 'undefined') {
+  if (typeof window === "undefined") {
     return <></>;
   }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-danger */
 import React from "react";
 import { extractStyles } from "evergreen-ui";
-import Document, { Head, Main, NextScript } from "next/document";
+import Document, { Html, Head, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
   static getInitialProps({ renderPage }) {
@@ -26,7 +26,7 @@ export default class MyDocument extends Document {
     const { css, hydrationScript } = this.props;
 
     return (
-      <html>
+      <Html>
         <Head>
           <title>SSR in Next.js</title>
           <style dangerouslySetInnerHTML={{ __html: css }} />
@@ -37,7 +37,7 @@ export default class MyDocument extends Document {
           {hydrationScript}
           <NextScript />
         </body>
-      </html>
+      </Html>
     );
   }
 }


### PR DESCRIPTION
Hey :D

This PR should solve the FOUC (flash of unstyled content).
To make it work, I had to copy this `_document.js` file from the evergreen template. This basically injects the CSS styles server-side
* https://github.com/segmentio/evergreen/blob/master/examples/ssr-next/pages/_document.js

Also, this one was helpful: https://www.reddit.com/r/nextjs/comments/qxyf2u/nextjs_fouc/hlcr5pv/?utm_source=reddit&utm_medium=web2x&context=3