### PR TITLE
Fix icon clickable issue in mobile

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -270,7 +270,7 @@ const Search = (props: Props) => {
 
   const showFiltersBtnMobile = (
     <Stack units={1} alignItems="center">
-      <ChevronRightIcon color="muted" />
+      <ChevronRightIcon color="muted" onClick={() => setShowSideSheet(true)} />
       <Text
         color="muted"
         className="clickable"


### PR DESCRIPTION
Issue: #14 
Make mobile "Filter by tags" chevron icon clickable