### PR TITLE
tag search works like OR filter, not AND

### DIFF
--- a/api/search.ts
+++ b/api/search.ts
@@ -21,9 +21,9 @@ export const tagsSearch: (
   packages: Array<Package>
 ) => (tags: NonEmptyArray<string>) => Array<Package> = (packages) => (tags) =>
   pipe(
-    tags,
-    array.reduce(packages, (acc, tag) =>
-      acc.filter((p) => p.tags.includes(tag))
+    packages,
+    array.filter((pckg) => pckg.tags.some(
+      (t) => tags.includes(t))
     )
   );
 

--- a/test/api/search.test.ts
+++ b/test/api/search.test.ts
@@ -1,0 +1,56 @@
+import { Package } from "../../api/domain";
+import { tagsSearch } from "../../api/search";
+import { flow, pipe } from "fp-ts/function";
+import {
+  array,
+  either,
+} from "fp-ts";
+import * as A from 'fp-ts/Array'
+
+describe("search API", () => {
+  const generatePackageWithTags = (tags: Array<string>) => {
+    return {
+      "tags": tags,
+      "name": "",
+      "author": "",
+      "description": "",
+      "title": "",
+      "version": "1.2.3",
+      "archive_url": "",
+      "archive_sha256_url": ""
+    }
+  };
+
+  test("selecting multiple tags combines all possible results", () => {
+    const packagesJson = [
+      generatePackageWithTags(["a"]),
+      generatePackageWithTags(["b"]),
+    ]
+
+    pipe(
+      packagesJson,
+      A.map(Package.decode),
+      A.map(either.fold(
+        flow( // decode fail
+          array.reduce("", (acc, curr) => `${acc}\n${curr.message}`),
+          x => { console.error(x); return x },
+          either.left
+        ),
+        pckg => either.right(pckg) // decode success; extract
+      )),
+
+      // transform Array<Either<E,T>> into Either<E, T[]>
+      array.sequence(either.Applicative),
+
+      either.fold(
+        (e) => console.log(e), // at least 1 element is left
+        (packages) => pipe( // all elements are right, so T[]
+          packages,
+          (packages) => tagsSearch(packages)(["a", "b"]),
+          (filtered) => expect(filtered.length).toEqual(2)
+        )
+      )
+    )
+
+  })
+});

--- a/test/api/search.test.ts
+++ b/test/api/search.test.ts
@@ -24,7 +24,8 @@ describe("search API", () => {
   test("selecting multiple tags combines all possible results", () => {
     const packagesJson = [
       generatePackageWithTags(["a"]),
-      generatePackageWithTags(["b"]),
+      generatePackageWithTags(["c", "d"]),
+      generatePackageWithTags(["x", "y", "z"]),
     ]
 
     pipe(
@@ -46,7 +47,7 @@ describe("search API", () => {
         (e) => console.log(e), // at least 1 element is left
         (packages) => pipe( // all elements are right, so T[]
           packages,
-          (packages) => tagsSearch(packages)(["a", "b"]),
+          (packages) => tagsSearch(packages)(["a", "c"]),
           (filtered) => expect(filtered.length).toEqual(2)
         )
       )


### PR DESCRIPTION
 - Used TDD red/green method
     - Decode two packages (tagged with `"A"` and `"B"` respectively)
     - Send them to tagsSearch function, with a tag search of `["A","B"]`
     - Now tagsSearch returns both packages. Previously it returned none.