### PR TITLE
Ignore single package decode failure to build the hub with only valid ones

### DIFF
--- a/api/packagesIndex.ts
+++ b/api/packagesIndex.ts
@@ -3,7 +3,6 @@ import { array, either, option, taskEither } from "fp-ts";
 import { flow, pipe } from "fp-ts/function";
 import { TaskEither } from "fp-ts/TaskEither";
 import { PackagesIndex } from "./domain";
-import { taskEitherLogError } from "./utils";
 
 const PACKAGE_INDEX_URL = process.env.PACKAGE_INDEX_URL || "";
 
@@ -43,7 +42,7 @@ const fetchPackagesIndexInternal = (cache: flatCache.Cache) =>
         ),
       taskEither.of
     ),
-    taskEitherLogError
+    taskEither.mapLeft(x => { console.error(x); return x }),
   );
 
 export const fetchPackagesIndex: TaskEither<Error, PackagesIndex> = pipe(

--- a/api/utils.ts
+++ b/api/utils.ts
@@ -1,15 +1,5 @@
-import { taskEither, string, array, readonlyNonEmptyArray as rnea } from "fp-ts";
+import { string, readonlyNonEmptyArray as rnea } from "fp-ts";
 import { flow, pipe } from "fp-ts/function";
-import { TaskEither } from "fp-ts/TaskEither";
-
-const logMiddleware = <E>(error: E) => {
-  console.error(error);
-  return error;
-};
-
-export const taskEitherLogError: <E, A>(
-  taskEither: TaskEither<E, A>
-) => TaskEither<E, A> = taskEither.mapLeft(logMiddleware);
 
 export const splitLines: (nLines: number) => (s: string) => rnea.ReadonlyNonEmptyArray<string> =
   (nLines) => (s) => pipe(

--- a/components/PackageCard.tsx
+++ b/components/PackageCard.tsx
@@ -34,7 +34,7 @@ export const PackageCard = (
       minHeight={majorScale(15)}
       {...pipe(
         props,
-        record.filterWithIndex((k, v) => !propsKeys.includes(k))
+        record.filterWithIndex((k, _) => !propsKeys.includes(k))
       )}
     >
       <Stack units={1} direction="column">

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "yaml": "^1.10.2"
   },
   "scripts": {
+    "clean-cache": "rm -rf .cache",
+    "prebuild": "yarn clean-cache",
+    "predev": "yarn clen-cache",
     "dev": "next dev",
     "build": "next build",
     "postbuild": "next-sitemap",

--- a/test/api/packagesIndex.test.ts
+++ b/test/api/packagesIndex.test.ts
@@ -1,0 +1,58 @@
+import { PackageArray } from "../../api/domain";
+import { pipe } from "fp-ts/function";
+import { either } from "fp-ts";
+
+describe("packagesIndex API", () => {
+    test("ignore single package decode failure", () => {
+        const valid = {
+            name: "name",
+            author: "author",
+            description: "description",
+            title: "title",
+            version: "0.0.1",
+            tags: [
+                "tag1",
+                "tag2",
+                "tag3",
+            ],
+            archive_url: "archive_url",
+            archive_sha256_url: "archive_sha256_url"
+        };
+
+        const missingProperty = {
+            name: "name",
+            author: "author",
+            description: "description",
+            title: "title",
+            version: "x.x.x",
+            archive_url: "archive_url",
+            archive_sha256_url: "archive_sha256_url"
+        }
+
+        const invalidProperty = {
+            name: 3,
+            author: "author",
+            description: "description",
+            title: "title",
+            version: "x.x.x",
+            tags: [
+                "tag1",
+                "tag2",
+                "tag3",
+            ],
+            archive_url: "archive_url",
+            archive_sha256_url: "archive_sha256_url"
+        }
+
+        const packagesIndex = [valid, missingProperty, invalidProperty];
+
+        pipe(
+            packagesIndex,
+            PackageArray.decode,
+            x => expect(x).toStrictEqual(either.right([{
+                ...valid,
+                id: "name-0.0.1"
+            }]))
+        )
+    })
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,9 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
Close #28 

- Add PackageArray codec ignoring single decoding failures
    - Decoding failures are logged to console.error for backtracking and awareness
    - Add related tests
- Add minors (no unused locals/params, clean-cache command)

# Test Plan

https://user-images.githubusercontent.com/16003164/187086305-88a8c2f1-b738-40d5-8d42-262207aacc16.mp4


