### PR TITLE
fix: remove typo from package page's metadata

### DIFF
--- a/pages/[packageName]/v/[version].tsx
+++ b/pages/[packageName]/v/[version].tsx
@@ -490,8 +490,8 @@ const VersionedPackagePage = (props: Props) => {
   const packagePage = (currentRepo: PackageRepo) => {
     const metaInfo = {
       title: `${currentRepo.package.name} ${currentRepo.package.version} | Espanso Hub`,
-      description: `Past in a terminal to install the \
-${currentRepo.package.name} package (v ${currentRepo.package.version}): \
+      description: `Paste in a terminal to install the \
+${currentRepo.package.name} package (v${currentRepo.package.version}): \
 ${currentRepo.package.description}`,
     };
     return (


### PR DESCRIPTION
Hello! I noticed this typo ("Past in a terminal") when I shared a package's link on Discord and saw its embed. I also removed the extra space between `v` and the version number. However, currently instead of giving the command the embeds give the description of the package after the ":", like

> Past in a terminal to install the lower-upper package (v 0.1.0): A simple package to convert clipboard content to lower case or UPPER case. (UNIX only)

(for <https://hub.espanso.org/lower-upper>)

Any suggestions are welcome!