### PR TITLE
Show Package name when displaying PackageCard

### DIFF
--- a/components/PackageCard.tsx
+++ b/components/PackageCard.tsx
@@ -4,9 +4,11 @@ import { isFeatured } from "../api/packageFeatured";
 import { TagBadgeGroup } from "./Tags/TagBadgeGroup";
 import { FeaturedBadge } from "./featured";
 import { Stack } from "./layout";
+import { PackageNamer } from "./PackageNamer";
 import { record } from "fp-ts";
 import { pipe } from "fp-ts/function";
 import { NextjsLink } from "./NextjsLink";
+
 
 type Props = {
   package: Package;
@@ -39,9 +41,13 @@ export const PackageCard = (
     >
       <Stack units={1} direction="column">
         <Pane display="flex">
-          <Heading flex={1}>{props.package.title} <Small>[{props.package.name}]</Small> </Heading>
-          {props.hideFeaturedBadge ||
-            (isFeatured(props.package) && <FeaturedBadge />)}
+          <Heading flex={1}>{props.package.title}</Heading>
+
+          <Card display="flex" alignItems="center">
+            <PackageNamer package={props.package} /> 
+            {props.hideFeaturedBadge ||
+              (isFeatured(props.package) && <FeaturedBadge />)}
+            </Card>
         </Pane>
         <Text>{props.package.description}</Text>
       </Stack>

--- a/components/PackageCard.tsx
+++ b/components/PackageCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Heading, majorScale, Pane, Text } from "evergreen-ui";
+import { Card, Heading, majorScale, Pane, Text, Small } from "evergreen-ui";
 import { Package } from "../api/domain";
 import { isFeatured } from "../api/packageFeatured";
 import { TagBadgeGroup } from "./Tags/TagBadgeGroup";
@@ -39,7 +39,7 @@ export const PackageCard = (
     >
       <Stack units={1} direction="column">
         <Pane display="flex">
-          <Heading flex={1}>{props.package.title}</Heading>
+          <Heading flex={1}>{props.package.title} <Small>[{props.package.name}]</Small> </Heading>
           {props.hideFeaturedBadge ||
             (isFeatured(props.package) && <FeaturedBadge />)}
         </Pane>

--- a/components/PackageCard.tsx
+++ b/components/PackageCard.tsx
@@ -1,4 +1,4 @@
-import { Card, Heading, majorScale, Pane, Text, Small } from "evergreen-ui";
+import { Card, Heading, majorScale, Pane, Text } from "evergreen-ui";
 import { Package } from "../api/domain";
 import { isFeatured } from "../api/packageFeatured";
 import { TagBadgeGroup } from "./Tags/TagBadgeGroup";

--- a/components/PackageNamer.tsx
+++ b/components/PackageNamer.tsx
@@ -1,0 +1,17 @@
+import { Code, majorScale } from "evergreen-ui";
+import { Package } from "../api/domain";
+import { espansoTheme } from "./EspansoThemeProvider";
+
+type Props = {
+  package: Package;
+};
+
+export const PackageNamer = (props: Props) => (
+    <Code
+      paddingRight={majorScale(1)}
+      appearance="minimal"
+      color={espansoTheme.colors.green600}
+    >
+      {props.package.name}
+    </Code>
+);

--- a/components/index.ts
+++ b/components/index.ts
@@ -7,6 +7,7 @@ export * from "./layout";
 export * from "./MDXRenderer";
 export * from "./Navbar";
 export * from "./PackageCard";
+export * from "./PackageNamer"
 export * from "./Tags/TagBadgeGroup";
 export * from "./BetaBanner";
 export * from "./Footer";

--- a/pages/[packageName]/v/[version].tsx
+++ b/pages/[packageName]/v/[version].tsx
@@ -13,7 +13,6 @@ import {
   Position,
   SelectMenu,
   SideSheet,
-  Small,
   Text,
 } from "evergreen-ui";
 import {
@@ -264,7 +263,7 @@ const VersionedPackagePage = (props: Props) => {
                   mobile: () => 600,
                 })}
               >
-                {currentRepo.package.name}
+                {currentRepo.package.title}
               </Heading>
               {isFeatured(currentRepo.package) && <FeaturedBadge />}
             </Stack>

--- a/pages/[packageName]/v/[version].tsx
+++ b/pages/[packageName]/v/[version].tsx
@@ -13,6 +13,7 @@ import {
   Position,
   SelectMenu,
   SideSheet,
+  Small,
   Text,
 } from "evergreen-ui";
 import {
@@ -55,6 +56,7 @@ import {
   MDXRenderer,
   Navbar,
   NextjsLink,
+  PackageNamer,
   Stack,
   TabProps,
   TagBadgeGroup,
@@ -325,7 +327,7 @@ const VersionedPackagePage = (props: Props) => {
               )}
             </Stack>
           </Pane>
-
+          
           <Text
           size={foldDevices({
             desktop: () => 400,
@@ -333,9 +335,19 @@ const VersionedPackagePage = (props: Props) => {
             mobile: () => 300,
           })}
           color={espansoTheme.colors.muted}
-        >
-          By {currentRepo.manifest.author}
-        </Text>
+          >
+            <PackageNamer package={currentRepo.package} />
+          </Text>
+          <Text
+          size={foldDevices({
+            desktop: () => 400,
+            tablet: () => 300,
+            mobile: () => 300,
+          })}
+          color={espansoTheme.colors.muted}
+          >
+            By {currentRepo.manifest.author}
+          </Text>
         </Stack>
         <Paragraph
           size={foldDevices({


### PR DESCRIPTION
Display each package's `.name` property on `PackageCard`, in small, `[]` wrapped text, just after the title. This helps users determine which packages they've already installed or used.

Resolves #35.